### PR TITLE
fix: update h1 heading to "Hello Datacor"

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function Home() {
         />
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
           <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
+            Hello Datacor
           </h1>
           <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
             Looking for a starting point or more instructions? Head over to{" "}


### PR DESCRIPTION
Changes the main heading on the home page to "Hello Datacor" as requested in issue #5.

Generated with [Claude Code](https://claude.ai/code)